### PR TITLE
Refactor to run continuously until signal interrupt or termination

### DIFF
--- a/src/Mshauneu/RdKafkaBundle/Topic/TopicConsumer.php
+++ b/src/Mshauneu/RdKafkaBundle/Topic/TopicConsumer.php
@@ -56,12 +56,19 @@ class TopicConsumer extends TopicCommunicator {
 		if (true !== $this->isConsuming) {
 			throw new \Exception ("Please call consumeStart first to start consuming message");
 		}
-		
-		while ($message = $this->consumerTopic->consume($partition, $timeoutInMs)) {
-			$consumer->consume($message->topic_name, $message->partition, $message->offset, $message->key, $message->payload);
-		}
+
+        if($message = $this->consumerTopic->consume($partition, $timeoutInMs)) {
+            return $consumer->consume($message->topic_name, $message->partition, $message->offset, $message->key, $message->payload);
+        }
+
+        return true;
 	}
-	
+
+	public function stop()
+    {
+        $this->consumeStop();
+    }
+
 	/**
 	 * @param number $partition
 	 */
@@ -69,6 +76,19 @@ class TopicConsumer extends TopicCommunicator {
 		$this->consumerTopic->consumeStop($partition);
 		$this->consumerTopic = null;
 		$this->isConsuming = false;
-	}	
+	}
+
+	public function restart()
+    {
+        // Implement a restart method
+    }
+
+    /**
+     * @return boolean
+     */
+    public function isConsuming()
+    {
+        return $this->isConsuming;
+    }
 	
 }


### PR DESCRIPTION
I made some changes to the command to behave more like the rabbitmq bundle.

This way, you do not have to continuously run the command to get to consume from Kafka. Feel free to decline this as it is a big change. I made the change in my forked copy because this is what we needed.