### PR TITLE
convert to use descriptive words for optional arguments

### DIFF
--- a/src/Mshauneu/RdKafkaBundle/Command/TopicConsumeCommand.php
+++ b/src/Mshauneu/RdKafkaBundle/Command/TopicConsumeCommand.php
@@ -29,7 +29,7 @@ class TopicConsumeCommand extends ContainerAwareCommand
 			->addOption('consumer', null, InputOption::VALUE_REQUIRED, 'Consumer')
 			->addOption('handler', null, InputOption::VALUE_REQUIRED, 'MessageHandler')
 			->addOption('partition', 'p', InputOption::VALUE_OPTIONAL, 'Partition', 0)
-			->addOption('offset', 'o', InputOption::VALUE_OPTIONAL, 'Offset', TopicCommunicator::OFFSET_BEGINNING)
+			->addOption('offset', 'o', InputOption::VALUE_OPTIONAL, 'Offset', 'beginning')
 			->addOption('timeout', 't', InputOption::VALUE_OPTIONAL, 'Timeout in ms', 1000);
 	}
 
@@ -57,9 +57,17 @@ class TopicConsumeCommand extends ContainerAwareCommand
             throw new \Exception("Partition needs to be a number in the range 0..2^32-1");
         }
 
-		$offset = $input->getOption('offset');
-        if(!is_numeric($offset)) {
-            throw new \Exception("Offset needs to be a number");
+        $offsetName = $input->getOption('offset');
+        switch (strtolower($offsetName)) {
+            case 'latest':
+            case 'last':
+                $offset = TopicConsumer::OFFSET_END;
+                break;
+            case 'beginning':
+            case 'first':
+            default:
+                $offset = TopicConsumer::OFFSET_BEGINNING;
+                break;
         }
 
 		$timeout = $input->getOption('timeout');


### PR DESCRIPTION
Changed this to use the same options as what is available in the config.yml for a better user experience.

Currently, you would have to pass in either a -1 or -2 for the values to work and the php-rdkafka library didn't like it.

The arguments come through as strings e.g. "-1" and "-2" but the is_numeric check in the command would fail and the php-rdkafka consumeStart required the offset to be an integer as well.

I could not figure how to convert it from a string to an integer and keep the same value. It seemed a better user experience to require values such as "beginning","first","last","latest" anyhow, so I stopped worrying about converting it.